### PR TITLE
Codespacesで起動できるように設定を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "Java",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/java:0-17",
+
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "true"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"vscjava.vscode-gradle",
+				"vscjava.vscode-lombok",
+				"naco-siren.gradle-language",
+				"vmware.vscode-boot-dev-pack",
+				"MS-CEINTL.vscode-language-pack-ja"
+			]
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "type": "java",
+      "name": "Spring Boot-MobileSuitDatabaseApplication<MobileSuitDatabase>",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "mainClass": "jp.co.sunarch.mobilesuitDatabase.MobileSuitDatabaseApplication",
+      "projectName": "MobileSuitDatabase",
+      "args": "",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}


### PR DESCRIPTION
Codespacesで起動するために、 `devcontainer.json` を追加しました。

以下の手順で、GitHubのリポジトリページから、ブラウザ上で開発環境を起動できるようになります。

1. リポジトリページの `Code => Codespaces => Create codespace on main` をクリック
   
<img width="979" alt="スクリーンショット 2023-03-15 15 46 02" src="https://user-images.githubusercontent.com/47751609/225229423-08cab1bd-3260-4589-9ae0-63436da64749.png">

2. 別タブでDev containerの起動画面が開くため、完了するまで待つ

<img width="979" alt="スクリーンショット 2023-03-15 15 47 16" src="https://user-images.githubusercontent.com/47751609/225228814-c595ccd3-27a3-45c8-9cc6-3bed47045113.png">

3. ブラウザでVSCodeのような画面が開き、拡張機能が自動でインストールされる

<img width="1332" alt="スクリーンショット 2023-03-15 15 49 33" src="https://user-images.githubusercontent.com/47751609/225228977-c6a77196-61df-433d-a3a5-049ea3679f8c.png">

4. ターミナルで以下のように入力し、アプリケーションを起動する

```sh
cd MobileSuitDatabase
mvn spring-boot:run
```

<img width="995" alt="スクリーンショット 2023-03-15 15 58 42" src="https://user-images.githubusercontent.com/47751609/225231013-4fca7c8d-9983-41a4-b67b-800a48d0b2b3.png">

5. アプリケーションが起動し、ブラウザーで開くボタンが表示されるため、クリック

<img width="995" alt="スクリーンショット 2023-03-15 15 59 54" src="https://user-images.githubusercontent.com/47751609/225231672-eea341cf-dc57-402c-84d4-f964c39ab91e.png">

6. ブラウザでアプリケーションが操作できるようになる

<img width="995" alt="スクリーンショット 2023-03-15 16 01 05" src="https://user-images.githubusercontent.com/47751609/225231795-21eb35ff-c24d-4c36-971b-af8ffc7d29c4.png">
